### PR TITLE
adding fosstodon verification tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
                 <br/>
 				<a href="https://blog.headup.ws"><img src="img/blogger_logo.png " height="60px" style="margin-top:10;margin-bottom:10;"/></a>
 				<a href="https://twitter.com/alsotoes"><img src="img/twitter.png" height="60px" style="margin-top:10;margin-bottom:10;"/></a>
+                <a rel="me" href="https://fosstodon.org/@alsotoes"></a>
                 <br/>
 				<a href="https://www.buymeacoffee.com/alvaro.soto"><img src="img/bmc-button.png" height="45px" width="160px" style="margin-top:5;margin-bottom:5;"/></a>
                 <br/>


### PR DESCRIPTION
Verification
You can verify yourself as the owner of the links in your profile metadata. For that, the linked website must contain a link back to your Mastodon profile. The link back must have a rel="me" attribute. The text content of the link does not matter. Here is an example:

<a rel="me" href="https://fosstodon.org/@alsotoes">Mastodon</a>